### PR TITLE
account for empty cells

### DIFF
--- a/table-filter.py
+++ b/table-filter.py
@@ -34,7 +34,8 @@ def tbl_contents(s):
     for row in s:
         para = []
         for col in row:
-            para.extend(col[0]['c'])
+            if len(col) > 0:
+                para.extend(col[0]['c'])
             para.append(inlatex(' & '))
         result.extend(para)
         result[-1] = inlatex(r' \\' '\n')


### PR DESCRIPTION
an empty cell in a table caused a crash before, because it was assumed to have an entry at index 0.